### PR TITLE
making bitwise_not a unop

### DIFF
--- a/src/ast.mli
+++ b/src/ast.mli
@@ -6,7 +6,7 @@ type bin_op =
   | Leq | Greater | Geq | And
   | Or
 
-type u_op = Not | Neg
+type u_op = Not | Neg | Bit_Not
 
 type p_type = Int_t | Bool_t | Double_t | Char_t | Unit_t
 

--- a/src/ast.mli
+++ b/src/ast.mli
@@ -6,7 +6,7 @@ type bin_op =
   | Leq | Greater | Geq | And
   | Or
 
-type u_op = Not | Neg | Bit_Not
+type u_op = Not | Neg
 
 type p_type = Int_t | Bool_t | Double_t | Char_t | Unit_t
 

--- a/src/ast.mli
+++ b/src/ast.mli
@@ -4,9 +4,10 @@ type bin_op =
     Add | Sub | Mult | Div
   | Mod | Equal | Neq | Less
   | Leq | Greater | Geq | And
-  | Or
+  | Or | Bit_And | Bit_Or | Bit_Xor
+  | Bit_RShift | Bit_LShift
 
-type u_op = Not | Neg
+type u_op = Not | Neg | Bit_Not
 
 type p_type = Int_t | Bool_t | Double_t | Char_t | Unit_t
 

--- a/src/ast.mli
+++ b/src/ast.mli
@@ -36,17 +36,8 @@ type actor_type = Actor_t of string
 
 type pool_type = Pool_t of actor_type list
 
-type bit_op =
-    Bit_And
-  | Bit_Or
-  | Bit_Xor
-  | Bit_Not
-  | Bit_RShift
-  | Bit_LShift
-
 and expr =
     Binop of expr * bin_op * expr
-  | Bitop of int * bit_op * int
   | Unop of u_op * expr
   | Id of string
   | Assign of string * expr

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -249,10 +249,10 @@ expr:
   | expr LOGIC_GEQ      expr                        { Binop($1, Geq, $3) }
   | expr LOGIC_AND      expr                        { Binop($1, And, $3) }
   | expr LOGIC_OR       expr                        { Binop($1, Or, $3) }
-  | expr BITWISE_AND    expr                        { Binop($1, Bit_And, $3)}
-  | expr BITWISE_OR     expr                        { Binop($1, Bit_Or, $3)}
-  | expr BITWISE_XOR    expr                        { Binop($1, Bit_Xor, $3)}
-  | expr BITWISE_NOT    expr                        { Binop($1, Bit_Not, $3)}
+  | expr BITWISE_AND    expr                        { Binop($1, Bit_And, $3) }
+  | expr BITWISE_OR     expr                        { Binop($1, Bit_Or, $3) }
+  | expr BITWISE_XOR    expr                        { Binop($1, Bit_Xor, $3) }
+  | expr BITWISE_NOT    expr                        { Unop($1, Bit_Not) }
   | expr BITWISE_RIGHT  expr                        { Binop($1, Bit_RShift, $3)}
   | expr BITWISE_LEFT   expr                        { Binop($1, Bit_LShift, $3)}
   | ARITH_MINUS expr %prec NEG                      { Unop(Neg, $2) }


### PR DESCRIPTION
super quick fix